### PR TITLE
fix: Add missing docs dependency group to documentation deployment pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install Dependencies
-        run: uv sync --extra azure --group dev
+        run: uv sync --all-extras --group dev --group docs
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
# Pull Request Overview

Fix documentation deployment pipeline by adding the missing `--group docs` flag to install MkDocs and related dependencies.

## Changes

- Updated `.github/workflows/docs.yml` to include `--group docs` in dependency installation step
- Changed from `uv sync --extra azure --group dev` to `uv sync --all-extras --group dev --group docs`

## Related Issues

Closes #11

## Test Details

- Pipeline fix is straightforward - adds missing dependency group
- Will be verified when workflow runs on tag push

## Future Work

None

## Notes

This is a one-line fix to resolve the `mkdocs: command not found` error in the documentation deployment workflow.