### PR TITLE
Docs: Fix broken navigation link for ADR 0017

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,4 +95,4 @@ nav:
           - 0014-importlib-lazy-import.md: adr/0014-importlib-lazy-import.md
           - 0015-terraform-managed-live-tests.md: adr/0015-terraform-managed-live-tests.md
           - 0016-mutually-exclusive-parameters-with-typeerror.md: adr/0016-mutually-exclusive-parameters-with-typeerror.md
-          - 0017-load-env-dotenv-path-parameter.md: a0017-load-env-dotenv-path-parameter.md
+          - 0017-load-env-dotenv-path-parameter.md: adr/0017-load-env-dotenv-path-parameter.md


### PR DESCRIPTION
# Pull Request Overview
This PR fixes a typo in the path to ADR 0017 within `mkdocs.yml`, repairing a broken navigation link in the documentation site.

## Changes
- Corrected the file path for "ADR 0017" in the `nav` section of `mkdocs.yml`.

## Related Issues
Closes #15 

## Test Details
This is a documentation configuration change. Verified that the documentation site builds successfully by running `nox -s docs_build`.

## Future Work
None

## Notes
None
