### PR TITLE
docs: Fix Contributing Guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ nox -s docs_serve      # Open http://localhost:8000
 
 ### Contributing
 
-See [Contributing Guide](http://localhost:8000/osoekawaitlab/envresolve/developer-guide/contributing/) for guidelines on:
+See [Contributing Guide](https://osoekawaitlab.github.io/envresolve/developer-guide/contributing/) for guidelines on:
 
 - Code style and conventions
 - Test-driven development workflow


### PR DESCRIPTION
# Pull Request Overview

Fixed incorrect Contributing Guide link in README.md (localhost URL → correct docs URL).

## Changes

- Updated Contributing Guide link from `http://localhost:8000/osoekawaitlab/envresolve/developer-guide/contributing/` to `https://osoekawaitlab.github.io/envresolve/developer-guide/contributing/`

## Related Issues

None (simple documentation fix)

## Test Details

- Link verified manually
- Documentation link is correct

## Future Work

None

## Notes

Simple typo fix - localhost URL was accidentally left in the README.