### PR TITLE
fix: update README to use uv sync and correct docs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,12 @@ pip install uv
 git clone https://github.com/osoekawaitlab/envresolve.git
 cd envresolve
 
-# Install dependencies (including dev dependencies)
-uv pip install -e ".[azure]" --group=dev
+# Install dependencies and create virtual environment
+uv sync --all-extras --all-groups
+
+# Activate virtual environment
+source .venv/bin/activate  # On Unix/macOS
+# .venv\Scripts\activate   # On Windows
 ```
 
 ### Running Tests
@@ -270,7 +274,7 @@ See [Live Azure Tests documentation](https://osoekawaitlab.github.io/envresolve/
 nox -s docs_build
 
 # Serve documentation locally (with live reload)
-nox -s docs_serve      # Open http://localhost:8000
+mkdocs serve           # Open http://localhost:8000
 ```
 
 ### Contributing

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -26,7 +26,7 @@ git clone https://github.com/osoekawaitlab/envresolve.git
 cd envresolve
 
 # Install with development dependencies
-uv sync
+uv sync --all-extras --all-groups
 
 # Run tests
 nox -s tests


### PR DESCRIPTION
# Pull Request Overview

Fix outdated documentation commands and setup instructions in README.md.

## Changes

- Changed setup to use `uv sync` instead of `uv venv` + `uv pip install`
- Changed non-existent `nox -s docs_serve` to `mkdocs serve`
- Aligned with `docs/user-guide/installation.md` which already uses `uv sync`

## Related Issues

Fixes #29

## Test Details

- Verified `nox --list` shows only `docs_build` session exists
- Confirmed `uv sync` creates `.venv` and installs all dependencies
- Checked `docs/user-guide/installation.md` uses the same `uv sync` pattern

## Future Work

None

## Notes

`uv sync` is the recommended way to install dependencies and create virtual environment. It combines `uv venv` + `uv pip install` into a single command.