### PR TITLE
fix: replace placeholder values in release template

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -2,39 +2,32 @@
 
 ### 🚀 Features
 
--  
--  
+
 
 ### 🐛 Fixes
 
--  
--  
+
 
 ### 🛠 Improvements
 
--  
--  
+
 
 ### 📚 Documentation
 
--  
--  
+
 
 ### 🧪 Testing
 
--  
--  
+
 
 ### 🔧 Maintenance
 
--  
--  
+
 
 ### 🔁 CI/CD & Infrastructure
 
--  
--  
+
 
 ## Full Changelog
 
-[(Full changelog link)](https://github.com/OWNER/REPO/compare/v{{PREVIOUS_VERSION}}...v{{VERSION}})
+[(Full changelog link)](https://github.com/osoekawaitlab/envresolve/compare/v{{PREVIOUS_VERSION}}...v{{VERSION}})


### PR DESCRIPTION
# Pull Request Overview

Fixed placeholder values in `.github/release_template.md` to make it ready for drafting release notes.

## Changes

- Replace `OWNER/REPO` with `osoekawaitlab/envresolve` in Full Changelog link
- Remove empty placeholder bullet points (`- `) from all sections

## Related Issues

Closes #32

## Test Details

Manual verification:
- Confirmed placeholder `OWNER/REPO` is replaced with actual repository name
- Confirmed all empty bullet points are removed
- Template structure and formatting preserved

## Future Work

None

## Notes

This is a simple documentation fix with no code changes.