### PR TITLE
Document release label policy in Contributing guide

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,8 @@ name: Documentation
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -223,6 +223,7 @@ Before creating a release tag:
 - [ ] **Run all quality checks**: `nox -s check_all`
 - [ ] **Commit version changes**: `git commit -m "chore: bump version to vX.Y.Z"`
 - [ ] **Push to main**: Ensure CI passes
+    - Documentation is automatically deployed to GitHub Pages on merge to main
 
 ### Release Creation
 
@@ -242,3 +243,56 @@ Before creating a release tag:
 - [ ] **Verify PyPI**: Check https://pypi.org/project/envresolve/
 - [ ] **Verify documentation**: Check https://osoekawaitlab.github.io/envresolve/
 - [ ] **Close milestone** (if applicable)
+
+## Release Note Labels
+
+Pull requests and issues use labels to automatically categorize changes in release notes. Applying the correct label ensures your contribution appears in the right section of the release.
+
+### Label Categories
+
+When creating a PR or issue, apply one of these labels:
+
+| Category | Labels | Use For |
+|----------|--------|---------|
+| 🚀 **Features** | `feature`, `enhancement` | New functionality or significant improvements to existing features |
+| 🐛 **Fixes** | `bug`, `fix` | Bug fixes and error corrections |
+| 🛠 **Improvements** | `improvement`, `refactor`, `perf` | Code refactoring, performance optimizations, and minor improvements |
+| 📚 **Documentation** | `docs`, `documentation` | Documentation updates, additions, or fixes |
+| 🧪 **Testing** | `test`, `testing` | Test additions, modifications, or test infrastructure changes |
+| 🔧 **Maintenance** | `maintenance`, `chore`, `dependencies` | Dependency updates, build configuration, and maintenance tasks |
+| 🔁 **CI/CD & Infrastructure** | `ci`, `infrastructure` | CI/CD pipeline changes and infrastructure configuration |
+
+### Examples
+
+- **Bug fix** → Apply `bug` or `fix` label
+- **New feature** → Apply `feature` or `enhancement` label
+- **Performance improvement** → Apply `improvement` or `perf` label
+- **Documentation update** → Apply `docs` or `documentation` label
+- **Test additions** → Apply `test` or `testing` label
+- **Dependency update** → Apply `dependencies` label
+
+### Excluded Labels
+
+The following labels do NOT appear in release notes:
+
+- `ignore-for-release` - Changes that should not be mentioned in releases
+- `duplicate` - Duplicate issues/PRs
+- `invalid` - Invalid issues/PRs
+- `wontfix` - Issues that will not be addressed
+
+### How Labels Affect Release Notes
+
+When a release is created, GitHub automatically generates release notes by grouping PRs according to their labels. Each PR appears under the category matching its label. This helps users quickly find relevant changes:
+
+```markdown
+## 🚀 Features
+- Add ignore_patterns parameter (#36)
+
+## 🐛 Fixes
+- Fix type error in resolver (#28)
+
+## 📚 Documentation
+- Update API documentation (#34)
+```
+
+**Tip**: If you're unsure which label to use, look at similar PRs or ask a maintainer.


### PR DESCRIPTION
# Pull Request Overview

This PR adds documentation for the release label policy to the Contributing guide, creates all required GitHub labels, and updates the documentation deployment workflow.

## Changes

- Added "Release Note Labels" section to `docs/developer-guide/contributing.md`:
  - Label categories table matching `.github/release.yml`
  - Usage examples for each category
  - Explanation of excluded labels
  - How labels affect release note generation
- Created missing GitHub labels (fix, improvement, refactor, perf, docs, test, testing, maintenance, chore, dependencies, ci, infrastructure, ignore-for-release)
- Updated feature label description for consistency
- Changed documentation deployment trigger from tag push to main branch merge in `.github/workflows/docs.yml`
- Updated Release Process section to note automatic docs deployment on main branch merge

## Related Issues

Closes #34

## Test Details

- Verified all label categories match `.github/release.yml`
- Confirmed all required labels exist in repository with `gh label list`
- Documentation formatting validated locally

## Future Work

None

## Notes

Contributors can now see which labels to apply to their PRs for proper release note categorization. Documentation will now deploy automatically on every merge to main instead of waiting for release tags.